### PR TITLE
修复资源文件加载时不考虑root配置的问题

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -13,7 +13,6 @@
 </script>
 <% } %>
 
-<!-- 使用 js() 辅助函数替代 script 标签 -->
 <%- js('js/clipboard.min') %>
 <%- js('js/jquery-1.4.3.min') %>
 <% if (theme.fancybox){ %>
@@ -58,7 +57,7 @@
     }
   };
 </script>
-<!-- 修复 MathJax 路径 -->
+
 <script type="text/javascript" id="MathJax-script" async
   src="<%- url_for('/mathjax/tex-chtml.js') %>">
 </script>

--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -13,13 +13,14 @@
 </script>
 <% } %>
 
-<script src="<%- url_for('js/clipboard.min.js') %>"></script>
-<script src="<%- url_for('js/jquery-1.4.3.min.js') %>"></script>
+<!-- 使用 js() 辅助函数替代 script 标签 -->
+<%- js('js/clipboard.min') %>
+<%- js('js/jquery-1.4.3.min') %>
 <% if (theme.fancybox){ %>
-<script src="<%- url_for('fancybox/jquery.fancybox-1.3.4.pack.js') %>"></script>
+  <%- js('fancybox/jquery.fancybox-1.3.4.pack') %>
 <% } %>
 
-<script src="<%- url_for('js/script.js') %>"></script>
+<%- js('js/script') %>
 <%- partial('gauges-analytics') %>
 
 <% if(theme.valine.enable && theme.valine.appId && theme.valine.appKey){ %>
@@ -57,18 +58,8 @@
     }
   };
 </script>
-<!-- <script type="text/x-mathjax-config">
-  MathJax.Hub.Config({
-    tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]},
-    CommonHTML: {
-      linebreaks: false
-    }
-  });
-  </script> -->
+<!-- 修复 MathJax 路径 -->
 <script type="text/javascript" id="MathJax-script" async
-  src="<%- url_for('mathjax/tex-chtml.js') %>">
+  src="<%- url_for('/mathjax/tex-chtml.js') %>">
 </script>
-<!-- <script type="text/javascript"
-   src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS_CHTML">
-</script> -->
 <% } %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -19,7 +19,6 @@
   }
   %>
   <title><% if (title){ %><%= title %> | <% } %><%= config.title %></title>
-  <!-- 修复字体文件路径 -->
   <%- css('/css/fonts/Chinese-normal-normal.min') %>
   <%- css('/css/fonts/ChineseMono-normal-normal.min') %>
   <%- css('/css/fonts/Chinese-italic-normal.min') %>
@@ -42,14 +41,11 @@
   <% if (theme.favicon){ %>
     <%- favicon_tag(theme.favicon) %>
   <% } %>
-  <!-- 修复主样式表路径 -->
   <%- css('css/style') %>
   <% if (theme.fancybox){ %>
-    <!-- 修复 fancybox 路径 -->
     <%- css('fancybox/jquery.fancybox-1.3.4') %>
   <% } %>
   <% if(theme.math.enable && theme.math.engine == 'katex'){ %>
-    <!-- 修复 KaTeX 路径 -->
     <link rel="stylesheet" href="<%- url_for('/katex/katex.min.css') %>" integrity="sha384-vKruj+a13U8yHIkAyGgK1J3ArTLzrFGBbBc0tDp4ad/EyewESeXE/Iv67Aj8gKZ0" crossorigin="anonymous">
 
     <!-- The loading of KaTeX is deferred to speed up page rendering -->

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -20,10 +20,10 @@
   %>
   <title><% if (title){ %><%= title %> | <% } %><%= config.title %></title>
   <!-- 修复字体文件路径 -->
-  <link rel="stylesheet" href="<%- url_for('/css/fonts/Chinese-normal-normal.min.css') %>">
-  <link rel="stylesheet" href="<%- url_for('/css/fonts/ChineseMono-normal-normal.min.css') %>">
-  <link rel="stylesheet" href="<%- url_for('/css/fonts/Chinese-italic-normal.min.css') %>">
-  <link rel="stylesheet" href="<%- url_for('/css/fonts/Chinese-normal-bold.min.css') %>">
+  <%- css('/css/fonts/Chinese-normal-normal.min') %>
+  <%- css('/css/fonts/ChineseMono-normal-normal.min') %>
+  <%- css('/css/fonts/Chinese-italic-normal.min') %>
+  <%- css('/css/fonts/Chinese-normal-bold.min') %>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <% if (page.description){ %>
   <meta name="description" itemprop="description" content="<%= page.description %>">

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -19,10 +19,11 @@
   }
   %>
   <title><% if (title){ %><%= title %> | <% } %><%= config.title %></title>
-  <link rel="stylesheet" href="/css/fonts/Chinese-normal-normal.min.css">
-  <link rel="stylesheet" href="/css/fonts/ChineseMono-normal-normal.min.css">
-  <link rel="stylesheet" href="/css/fonts/Chinese-italic-normal.min.css">
-  <link rel="stylesheet" href="/css/fonts/Chinese-normal-bold.min.css">
+  <!-- 修复字体文件路径 -->
+  <link rel="stylesheet" href="<%- url_for('/css/fonts/Chinese-normal-normal.min.css') %>">
+  <link rel="stylesheet" href="<%- url_for('/css/fonts/ChineseMono-normal-normal.min.css') %>">
+  <link rel="stylesheet" href="<%- url_for('/css/fonts/Chinese-italic-normal.min.css') %>">
+  <link rel="stylesheet" href="<%- url_for('/css/fonts/Chinese-normal-bold.min.css') %>">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <% if (page.description){ %>
   <meta name="description" itemprop="description" content="<%= page.description %>">
@@ -41,18 +42,21 @@
   <% if (theme.favicon){ %>
     <%- favicon_tag(theme.favicon) %>
   <% } %>
-  <link rel="stylesheet" href="/css/style.css">
+  <!-- 修复主样式表路径 -->
+  <%- css('css/style') %>
   <% if (theme.fancybox){ %>
-    <link rel="stylesheet" href="/fancybox/jquery.fancybox-1.3.4.css">
+    <!-- 修复 fancybox 路径 -->
+    <%- css('fancybox/jquery.fancybox-1.3.4') %>
   <% } %>
   <% if(theme.math.enable && theme.math.engine == 'katex'){ %>
-    <link rel="stylesheet" href="/katex/katex.min.css" integrity="sha384-vKruj+a13U8yHIkAyGgK1J3ArTLzrFGBbBc0tDp4ad/EyewESeXE/Iv67Aj8gKZ0" crossorigin="anonymous">
+    <!-- 修复 KaTeX 路径 -->
+    <link rel="stylesheet" href="<%- url_for('/katex/katex.min.css') %>" integrity="sha384-vKruj+a13U8yHIkAyGgK1J3ArTLzrFGBbBc0tDp4ad/EyewESeXE/Iv67Aj8gKZ0" crossorigin="anonymous">
 
     <!-- The loading of KaTeX is deferred to speed up page rendering -->
-    <script defer src="/katex/katex.min.js" integrity="sha384-PwRUT/YqbnEjkZO0zZxNqcxACrXe+j766U2amXcgMg5457rve2Y7I6ZJSm2A0mS4" crossorigin="anonymous"></script>
+    <script defer src="<%- url_for('/katex/katex.min.js') %>" integrity="sha384-PwRUT/YqbnEjkZO0zZxNqcxACrXe+j766U2amXcgMg5457rve2Y7I6ZJSm2A0mS4" crossorigin="anonymous"></script>
 
     <!-- To automatically render math in text elements, include the auto-render extension: -->
-    <script defer src="/katex/contrib/auto-render.min.js" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous"
+    <script defer src="<%- url_for('/katex/contrib/auto-render.min.js') %>" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous"
         onload="renderMathInElement(document.body);"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function() {

--- a/layout/_partial/post/gallery.ejs
+++ b/layout/_partial/post/gallery.ejs
@@ -2,8 +2,7 @@
 <div class="article-gallery">
   <div class="article-gallery-photos">
     <% post.photos.forEach(function(photo, i){ %>
-        <div class="article-gallery-img"><img src="<%- url_for(photo, {relative: false}) %>" itemprop="image"></div>
-      </a>
+        <div class="article-gallery-img"><img src="<%- url_for(photo) %>" itemprop="image"></div>
     <% }) %>
   </div>
 </div>


### PR DESCRIPTION
在使用github静态页面托管服务时，我发现mashiro对资源文件（css/js/img）的加载并未考虑hexo配置文件中的root字段，并会直接取url字段的base_url部分作为请求资源文件的base_url。直接导致的情况是，当我想使用’https://username.github.io/project‘作为我的blog入口时，页面的资源文件无法正常加载。
因此我参考hexo的API修正了这一问题，主要变更位于./themes/mashiro/layout/_partial/head.ejs部分，如果作者认为这一变更合理，烦请合并。