### PR TITLE
Fix: wrong url in nav bar

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -2,11 +2,11 @@
   <nav id="main-nav" class="outer">
     <a id="main-nav-toggle" class="nav-icon"></a>
     <% for (var i in theme.menu){ %>
-      <a class="main-nav-link" href="<%- url_for(theme.menu[i]) %>"><%= i %></a>
+      <a class="main-nav-link" href="<%- url_for(theme.menu[i], {relative: theme.menu[i][0] != '/'}) %>"><%= i %></a>
     <% } %>
     <div class="main-nav-space-between"></div>
     <% if (theme.rss){ %>
-      <a id="nav-rss-link" class="nav-icon" href="<%- url_for(theme.rss) %>" title="<%= __('rss_feed') %>"></a>
+      <a id="nav-rss-link" class="nav-icon" href="<%- url_for(theme.rss, {relative: theme.menu[i][0] != '/'}) %>" title="<%= __('rss_feed') %>"></a>
     <% } %>
   </nav>
 </div>

--- a/layout/_partial/mobile-nav.ejs
+++ b/layout/_partial/mobile-nav.ejs
@@ -1,5 +1,5 @@
 <nav id="mobile-nav">
   <% for (var i in theme.menu){ %>
-    <a href="<%- url_for(theme.menu[i]) %>" class="mobile-nav-link"><%= i %></a>
+    <a href="<%- url_for(theme.menu[i], {relative: theme.menu[i][0] != '/'}) %>" class="mobile-nav-link"><%= i %></a>
   <% } %>
 </nav>


### PR DESCRIPTION
When both relative_url and root are configured in _config.yml, and menu in _config.mashiro.yml are configured as absolute paths as below, URLs in nav bar have absolute paths without root being prepended.

@_config.yml
relative_link: true
root: /blog/

@_config.mashiro.yml
menu:
  Home: /
  Archives: /archives/
  About: /about/

In the example above, link is rendered as <a class="main-nav-link" href="/archives/">Archives</a>. The reason is, relative_link config causes the path configured in menu to be passed to relativeUrlHelper(), which handles absolute paths wrongly.

We can blame this to our user to enable relative_link while using absolute path in menu, but we can be more kind to our users, by controlling who the path is passed to in the nav bar ejs file. Specifically, if the path starts with '/', treat as relative, otherwise treat as absolute, no matter how relative_link is configured.